### PR TITLE
Link created instance into variable.

### DIFF
--- a/category-featured-images.js
+++ b/category-featured-images.js
@@ -23,7 +23,7 @@ jQuery(document).ready( function() {
 			button: { text: 'Choose image' },
 			multiple: false
 		});
- 
+
 	//When a file is selected, grab the URL and set it as the text field's value
 		cfi_media_upload.on( 'select', function() {
 			attachment = cfi_media_upload.state().get( 'selection' ).first().toJSON();

--- a/category-featured-images.js
+++ b/category-featured-images.js
@@ -1,5 +1,5 @@
 /**
- * Plugin Name: Category Featured Images
+ * Plugin Name: Category Featured Images (KR)
  * Author: Mattia Roccoberton
  * Author URI: http://blocknot.es
  * License: GPL3

--- a/category-featured-images.php
+++ b/category-featured-images.php
@@ -1,12 +1,14 @@
 <?php
 /**
  * Plugin Name: Category Featured Images
- * Plugin URI: https://github.com/blocknotes/wordpress_category_featured_images
+ * Plugin URI: https://github.com/karrirasinmaki/wordpress_category_featured_images/
  * Description: Allows to set featured images for categories, posts without a featured image will show the category's image (Posts \ Categories \ Edit category)
- * Version: 1.1.0
- * Author: Mattia Roccoberton
- * Author URI: http://blocknot.es
+ * Version: 1.1.0.1
  * License: GPL3
+ * 
+ * Original Author: Mattia Roccoberton
+ * Original Author URI: http://blocknot.es * 
+ * Original Plugin URI : https://github.com/blocknotes/wordpress_category_featured_images
  */
 
 class category_featured_images

--- a/category-featured-images.php
+++ b/category-featured-images.php
@@ -3,11 +3,13 @@
  * Plugin Name: Category Featured Images
  * Plugin URI: https://github.com/karrirasinmaki/wordpress_category_featured_images/
  * Description: Allows to set featured images for categories, posts without a featured image will show the category's image (Posts \ Categories \ Edit category)
+ * Author: Karri Rasinmäki
+ * Author URI: http://karri.rasinmaki.fi
  * Version: 1.1.0.1
  * License: GPL3
  * 
  * Original Author: Mattia Roccoberton
- * Original Author URI: http://blocknot.es * 
+ * Original Author URI: http://blocknot.es
  * Original Plugin URI : https://github.com/blocknotes/wordpress_category_featured_images
  */
 

--- a/category-featured-images.php
+++ b/category-featured-images.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: Category Featured Images
- * Plugin URI: https://github.com/blocknotes/wordpress_category_featured_images
+ * Plugin Name: Category Featured Images (KR)
+ * Plugin URI: https://github.com/karrirasinmaki/wordpress_category_featured_images/
  * Description: Allows to set featured images for categories, posts without a featured image will show the category's image (Posts \ Categories \ Edit category)
  * Author: Karri Rasinmäki
  * Author URI: http://karri.rasinmaki.fi

--- a/category-featured-images.php
+++ b/category-featured-images.php
@@ -176,7 +176,7 @@ class category_featured_images
 	}
 }
 
-new category_featured_images();
+$category_featured_images = new category_featured_images();
 
 function cfi_featured_image( $args )
 {

--- a/cfi-styles.css
+++ b/cfi-styles.css
@@ -1,5 +1,5 @@
 /**
- * Plugin Name: Category Featured Images
+ * Plugin Name: Category Featured Images (KR)
  * Author: Mattia Roccoberton
  * Author URI: http://blocknot.es
  * License: GPL3

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+  "name": "karrirasinmaki/wordpress_category_featured_images",
+  "description": "",
+  "keywords": ["wordpress", "plugin"],
+  "homepage": "http://rivermouth.fi",
+  "license": "All rights reserved to author and parties with granted permissions.",
+  "authors": [
+    {
+      "name": "Karri Rasinmäki",
+      "email": "karri.rasinmaki@gmail.com",
+      "homepage": "http://karri.rasinmaki.fi"
+    }
+  ],
+  "type": "wordpress-plugin",
+  "require": {
+    "php": ">=5.3.2"
+  }
+}


### PR DESCRIPTION
Link created `category_featured_images` instance into a global variable so user can remove hooks they do not need.

For example, I don't want to show category featured image as a default image for posts, so with this variable I can remove `get_post_metadata` action from my theme's code.

``` php
global $category_featured_images;
remove_filter( 'get_post_metadata', array( $category_featured_images, 'get_post_metadata' ), 10 );
```
